### PR TITLE
don't use git_config for BWA + use - to separate datestamp from version when using specific commit

### DIFF
--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.17-20220923-GCCcore-12.3.0.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.17-20220923-GCCcore-12.3.0.eb
@@ -17,10 +17,10 @@
 ##
 
 name = 'BWA'
-version = '0.7.17.20220923'
+local_commit = '139f68f'
+version = '0.7.17-20220923'
 
 homepage = 'http://bio-bwa.sourceforge.net/'
-
 description = """
  Burrows-Wheeler Aligner (BWA) is an efficient program that aligns relatively
  short nucleotide sequences against a long reference sequence such as the human
@@ -30,18 +30,9 @@ description = """
 toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
 toolchainopts = {'pic': True}
 
-local_commit = '139f68f'
-
-sources = [{
-    'filename': '%s-%s-%s.tar.gz' % (name, version, local_commit),
-    'git_config': {
-        'url': 'https://github.com/lh3',
-        'repo_name': 'bwa',
-        'commit': local_commit,
-        'recursive': True,
-    },
-}]
-checksums = ['127d3f82ccc3bf7e918d2e64cafc0ffc49ff841b0955327f4666ca448364859f']
+source_urls = ['https://github.com/lh3/bwa/archive']
+sources = [{'download_filename': '%s.tar.gz' % local_commit, 'filename': SOURCE_TAR_GZ}]
+checksums = ['be460d6e13ddf34896aafae00bad71e05a0b9f7e23490eeeca8ad257065f5e60']
 
 builddependencies = [('binutils', '2.40')]
 


### PR DESCRIPTION
@hvelab for https://github.com/easybuilders/easybuild-easyconfigs/pull/19820